### PR TITLE
feat: Add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/devcontainers/rust
+
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
+ENV TYPST_FONT_PATHS=/workspaces/Thesis-BPI/fonts
+
+RUN cargo install --locked typst-cli
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "build": { "dockerfile": "Dockerfile" },
+  "name": "Typst",
+  // "workspaceFolder": "/workspace",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "myriad-dreamin.tinymist",
+        "shardulm94.trailing-spaces",
+        "stkb.rewrap",
+        "tomoki1207.pdf",
+        "streetsidesoftware.code-spell-checker",
+        "streetsidesoftware.code-spell-checker-german"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "[typst]": {
+          "editor.formatOnSave": true
+        },
+        "tinymist.formatterMode": "typstyle",
+        "files.associations": {
+          "*.typ": "typst"
+        }
+      }
+    }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {}
+  }
+}


### PR DESCRIPTION
Devcontainers enable a reproducible environment for everyone using the repository with vscode.

For the dev container configuration, I added installs typist, tiny mist, and various extensions for working with typist writing in general. 