### PR TITLE
Support Images for "signing" the digital Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This template exports the `clean-dhbw` function with the following named argumen
 - student-id (str*): Student ID of the author
 - course (str*): Course of the author
 - course-of-studies (str*): Course of studies of the author
+- signature (str): Optional path to an image of the authors signature (used for the declaration of authorship)
 - company (dictionary): Company of the author (only needed when `at-university` is `false`) with the following named arguments:
   - name (str*): Name of the company
   - post-code (str): Post code of the company

--- a/declaration-of-authorship.typ
+++ b/declaration-of-authorship.typ
@@ -53,15 +53,25 @@
       columns: (1fr, 1fr),
       gutter: 20pt,
       ..authors.map(author => {
-        v(3.5em)
-        line(length: 80%)
+        rect(
+          width: 80%, height: 3.5em, inset: 1pt,
+          stroke: (top: none, y: none, bottom: black),
+          if author.keys().contains("signature") {
+            image(author.signature, width: 100%, height: 100%, fit: "contain")
+          }
+        )
         author.name
       })
     )
   } else {
     for author in authors {
-      v(4em)
-      line(length: 40%)
+      rect(
+        width: 40%, height: 4em, inset: 1pt,
+        stroke: (top: none, y: none, bottom: black),
+        if author.keys().contains("signature") {
+            image(author.signature, width: 100%, height: 100%, fit: "contain")
+        }
+      )
       author.name
     }
   }


### PR DESCRIPTION
I have implemented the feature from https://github.com/roland-KA/clean-dhbw-typst-template/issues/8
The signatures are now a rectangle with only a stroke at the bottom, instead of a vertical skip and a line, this allows the signature to be closer to the line. The rect will contain the image of the signature if one is passed to clean-dhbw. When skaling the images to fit the rectangle, aspect-ratio is preserved.

This code:
```typ
#import "lib.typ": *

#show: clean-dhbw.with(
  authors: (
    ( name: "No Signature",
                                                                           student-id:"0",course:"x",course-of-studies:"y"),
    ( name: "Overly Vertical Signature", signature: "vert.png",
                                                                           student-id:"0",course:"x",course-of-studies:"y"),
    ( name: "Horizantally Exaggerated Signature", signature: "hori.png",
                                                                           student-id:"0",course:"x",course-of-studies:"y"),
    ( name: "Normal Signature", signature: "norm.png",
                                                                           student-id:"0",course:"x",course-of-studies:"y"),
  ),

  title:"a",type-of-thesis:"b",city:"c",at-university:true,date:datetime.today(),language:"de",supervisor:(university: "f"),university:"g",university-location:"h",university-short:"i"
)
```
Produces this declaration of authorschip:
![image](https://github.com/user-attachments/assets/5dc98197-9d09-4b22-975a-4fcf01768ca0)
(the red outlines are part of the used images)
|Overly Vertical|Horizantally Exaggerated|Normal|
|---|---|---|
|![vert](https://github.com/user-attachments/assets/566ecb8c-f049-48e6-a5fb-3db81a9cf1ee)|![hori](https://github.com/user-attachments/assets/5dc31a7d-68a4-4549-a25c-8c5edeeb242a)|![norm](https://github.com/user-attachments/assets/2bb09d46-7fc6-4cf4-98dc-f417d44be006)|
