### PR TITLE
fix: Remove non-existent type-of-degree variable to fix template errors

### DIFF
--- a/titlepage.typ
+++ b/titlepage.typ
@@ -72,7 +72,7 @@
       0pt
     }
 
-    if (type-of-degree == none and type-of-thesis == none) {
+    if (type-of-thesis == none) {
       title-spacing = 0em
     }
 


### PR DESCRIPTION
This change removes the type-of-degree variable from the condition
```
if (type-of-degree == none and type-of-thesis == none)
```

because type-of-degree is not defined anywhere in the Typst template.

Referencing a non-existent variable caused template errors and led to issues such as the confidentiality marker not being rendered correctly.

By removing this variable, the template now behaves as expected and avoids unnecessary errors.