### PR TITLE
Replace confidentiality marker dot with explicit textual notice

### DIFF
--- a/locale.typ
+++ b/locale.typ
@@ -121,3 +121,8 @@ The content of this thesis may not be made available, either in its entirety or 
   "de": "Anhang",
   "en": "Appendix",
 )
+
+#let CONFIDENTIALITY_MARKER = (
+  "de": "Diese Arbeit enthält einen Sperrvermerk",
+  "en": "This thesis contains a confidentiality notice",
+)

--- a/titlepage.typ
+++ b/titlepage.typ
@@ -208,7 +208,8 @@
 
       // confidentiality - marker
       if (confidentiality-marker.display and show-confidentiality-statement) {
-        text(weight: "bold", fill: rgb(226, 0, 26), "Diese Arbeit enthält einen Sperrvermerk")
+        text(weight: "bold", fill: rgb(226, 0, 26), 
+        CONFIDENTIALITY_MARKER.at(language))
       },
     ),
   )

--- a/titlepage.typ
+++ b/titlepage.typ
@@ -20,12 +20,11 @@
   university-short,
   page-grid,
 ) = {
-
   // ---------- Page Setup ---------------------------------------
 
-  set page(     
+  set page(
     // identical to document
-    margin: (top: 4cm, bottom: 3cm, left: 4cm, right: 3cm),   
+    margin: (top: 4cm, bottom: 3cm, left: 4cm, right: 3cm),
   )
   // The whole page in `title-font`, all elements centered
   set text(font: title-font, size: page-grid)
@@ -33,43 +32,35 @@
 
   // ---------- Logo(s) ---------------------------------------
 
-  if logo-left != none and logo-right == none {           // one logo: centered
-    place(                                
+  if logo-left != none and logo-right == none {
+    // one logo: centered
+    place(
       top + center,
       dy: -3 * page-grid,
-      box(logo-left, height: 3 * page-grid) 
+      box(logo-left, height: 3 * page-grid),
     )
-  } else if logo-left != none and logo-right != none {    // two logos: left & right
+  } else if logo-left != none and logo-right != none {
+    // two logos: left & right
     place(
       top + left,
       dy: -4 * page-grid,
-      box(logo-left, height: 3 * page-grid) 
+      box(logo-left, height: 3 * page-grid),
     )
     place(
       top + right,
       dy: -4 * page-grid,
-      box(logo-right, height: 3 * page-grid) 
+      box(logo-right, height: 3 * page-grid),
     )
   }
 
   // ---------- Title ---------------------------------------
 
-  v(7 * page-grid)     
+  v(7 * page-grid)
   text(weight: "bold", fill: luma(80), size: 1.5 * page-grid, title)
   v(page-grid)
-  
-  // ---------- Confidentiality Marker (optional) ---------------------------------------
-  
-  if (confidentiality-marker.display and show-confidentiality-statement) {
-    place(
-      dy: 2 * page-grid,
-      bottom + center,
-      text(red, 15pt, weight: "bold", "Diese Arbeit enthält einen Sperrvermerk")
-    )
-  }
 
   // ---------- Sub-Title-Infos ---------------------------------------
-  // 
+  //
   // type of thesis (optional)
   if (type-of-thesis != none and type-of-thesis.len() > 0) {
     align(center, text(size: page-grid, type-of-thesis))
@@ -77,7 +68,7 @@
   }
 
   // course of studies
-  text(TITLEPAGE_SECTION_B.at(language) + authors.map(author => author.course-of-studies).dedup().join(" | "),)
+  text(TITLEPAGE_SECTION_B.at(language) + authors.map(author => author.course-of-studies).dedup().join(" | "))
   v(0.25 * page-grid)
 
   // university
@@ -101,7 +92,7 @@
           text(author.name)
         },
       ))
-    )
+    ),
   )
 
   // ---------- Info-Block ---------------------------------------
@@ -109,106 +100,116 @@
   set text(size: 11pt)
   place(
     bottom + center,
-    grid(
-      columns: (auto, auto),
-      row-gutter: 1em,
-      column-gutter: 1em,
-      align: (right, left),
+    stack(
+      dir: ttb,
+      spacing: 1em,
+      grid(
+        columns: (auto, auto),
+        row-gutter: 1em,
+        column-gutter: 1em,
+        align: (right, left),
 
-      // submission date
-      text(weight: "bold", fill: luma(80), TITLEPAGE_DATE.at(language)),
-      text(
-        if (type(date) == datetime) {
-          date.display(date-format)
-        } else {
-          date.at(0).display(date-format) + [ -- ] + date.at(1).display(date-format)
+        // submission date
+        text(weight: "bold", fill: luma(80), TITLEPAGE_DATE.at(language)),
+        text(
+          if (type(date) == datetime) {
+            date.display(date-format)
+          } else {
+            date.at(0).display(date-format) + [ -- ] + date.at(1).display(date-format)
+          },
+        ),
+
+        // students
+        align(text(weight: "bold", fill: luma(80), TITLEPAGE_STUDENT_ID.at(language)), top),
+        stack(
+          dir: ttb,
+          for author in authors {
+            text([#author.student-id, #author.course])
+            linebreak()
+          },
+        ),
+
+        // company
+        ..if (not at-university) {
+          (
+            align(text(weight: "bold", fill: luma(80), TITLEPAGE_COMPANY.at(language)), top),
+            stack(
+              dir: ttb,
+              for author in authors {
+                let company-address = ""
+
+                // company name
+                if (
+                  "name" in author.company and author.company.name != none and author.company.name != ""
+                ) {
+                  company-address += author.company.name
+                } else {
+                  panic(
+                    "Author '"
+                      + author.name
+                      + "' is missing a company name. Add the 'name' attribute to the company object.",
+                  )
+                }
+
+                // company address (optional)
+                if (
+                  "post-code" in author.company and author.company.post-code != none and author.company.post-code != ""
+                ) {
+                  company-address += text([, #author.company.post-code])
+                }
+
+                // company city
+                if (
+                  "city" in author.company and author.company.city != none and author.company.city != ""
+                ) {
+                  company-address += text([, #author.company.city])
+                } else {
+                  panic(
+                    "Author '"
+                      + author.name
+                      + "' is missing the city of the company. Add the 'city' attribute to the company object.",
+                  )
+                }
+
+                // company country (optional)
+                if (
+                  "country" in author.company and author.company.country != none and author.company.country != ""
+                ) {
+                  company-address += text([, #author.company.country])
+                }
+
+                company-address
+                linebreak()
+              },
+            ),
+          )
+        },
+
+        // company supervisor
+        ..if ("company" in supervisor) {
+          (
+            text(weight: "bold", fill: luma(80), TITLEPAGE_COMPANY_SUPERVISOR.at(language)),
+            if (type(supervisor.company) == str) { text(supervisor.company) },
+          )
+        },
+
+        // university supervisor
+        ..if ("university" in supervisor) {
+          (
+            text(
+              weight: "bold",
+              fill: luma(80),
+              TITLEPAGE_SUPERVISOR.at(language) + university-short + [:],
+            ),
+            if (type(supervisor.university) == str) { text(supervisor.university) },
+          )
         },
       ),
 
-      // students
-      align(text(weight: "bold", fill: luma(80), TITLEPAGE_STUDENT_ID.at(language)), top),
-      stack(
-        dir: ttb,
-        for author in authors {
-          text([#author.student-id, #author.course])
-          linebreak()
-        }
-      ),
-
-      // company
-      ..if (not at-university) { 
-        (align(text(weight: "bold", fill: luma(80), TITLEPAGE_COMPANY.at(language)), top),
-         stack(
-          dir: ttb,
-          for author in authors {
-            let company-address = ""
-
-            // company name
-            if (
-              "name" in author.company and
-              author.company.name != none and
-              author.company.name != ""
-              ) {
-              company-address+= author.company.name
-            } else {
-              panic("Author '" + author.name + "' is missing a company name. Add the 'name' attribute to the company object.")
-            }
-
-            // company address (optional)
-            if (
-              "post-code" in author.company and
-              author.company.post-code != none and
-              author.company.post-code != ""
-              ) {
-              company-address+= text([, #author.company.post-code])
-            }
-
-            // company city
-            if (
-              "city" in author.company and
-              author.company.city != none and
-              author.company.city != ""
-              ) {
-              company-address+= text([, #author.company.city])
-            } else {
-              panic("Author '" + author.name + "' is missing the city of the company. Add the 'city' attribute to the company object.")
-            }
-
-            // company country (optional)
-            if (
-              "country" in author.company and
-              author.company.country != none and
-              author.company.country != ""
-            ) {
-              company-address+= text([, #author.company.country])
-            }
-
-            company-address
-            linebreak()
-          }
-        )
-       )
+      // confidentiality - marker
+      if (confidentiality-marker.display and show-confidentiality-statement) {
+        text(weight: "bold", fill: rgb(226, 0, 26), "Diese Arbeit enthält einen Sperrvermerk")
       },
-
-      // company supervisor
-      ..if ("company" in supervisor) {
-        (
-          text(weight: "bold", fill: luma(80), TITLEPAGE_COMPANY_SUPERVISOR.at(language)),
-          if (type(supervisor.company) == str) {text(supervisor.company)}
-        )
-      },
-
-      // university supervisor
-      ..if ("university" in supervisor) {
-        (
-          text(
-            weight: "bold", fill: luma(80), 
-            TITLEPAGE_SUPERVISOR.at(language) + university-short + [:]
-          ),
-          if (type(supervisor.university) == str) {text(supervisor.university)}
-        )
-      },
-
-    )
+    ),
   )
 }

--- a/titlepage.typ
+++ b/titlepage.typ
@@ -60,61 +60,13 @@
   
   // ---------- Confidentiality Marker (optional) ---------------------------------------
   
-  if (confidentiality-marker.display) {
+  if (confidentiality-marker.display and show-confidentiality-statement) {
     place(
       dy: 2 * page-grid,
       bottom + center,
       text(red, 15pt, weight: "bold", "Diese Arbeit enthält einen Sperrvermerk")
     )
   }
-
-  // if (confidentiality-marker.display) {
-  //   let size = 7em
-  //   let display = false
-  //   let title-spacing = 2em
-  //   let x-offset = 0pt
-
-  //   let y-offset = if (many-authors) {
-  //     7pt
-  //   } else {
-  //     0pt
-  //   }
-
-  //   if (type-of-thesis == none) {
-  //     title-spacing = 0em
-  //   }
-
-  //   if ("display" in confidentiality-marker) {
-  //     display = confidentiality-marker.display
-  //   }
-  //   if ("offset-x" in confidentiality-marker) {
-  //     x-offset = confidentiality-marker.offset-x
-  //   }
-  //   if ("offset-y" in confidentiality-marker) {
-  //     y-offset = confidentiality-marker.offset-y
-  //   }
-  //   if ("size" in confidentiality-marker) {
-  //     size = confidentiality-marker.size
-  //   }
-  //   if ("title-spacing" in confidentiality-marker) {
-  //     confidentiality-marker.title-spacing
-  //   }
-
-  //   v(title-spacing)
-
-  //   let color = if (show-confidentiality-statement) {
-  //     red
-  //   } else {
-  //     green.darken(5%)
-  //   }
-
-  //   place(
-  //     right,
-  //     dx: 35pt + x-offset,
-  //     dy: -70pt + y-offset,
-  //     circle(radius: size / 2, fill: color),
-  //   )
-  // }
 
   // ---------- Sub-Title-Infos ---------------------------------------
   // 

--- a/titlepage.typ
+++ b/titlepage.typ
@@ -59,54 +59,62 @@
   v(page-grid)
   
   // ---------- Confidentiality Marker (optional) ---------------------------------------
-
+  
   if (confidentiality-marker.display) {
-    let size = 7em
-    let display = false
-    let title-spacing = 2em
-    let x-offset = 0pt
-
-    let y-offset = if (many-authors) {
-      7pt
-    } else {
-      0pt
-    }
-
-    if (type-of-thesis == none) {
-      title-spacing = 0em
-    }
-
-    if ("display" in confidentiality-marker) {
-      display = confidentiality-marker.display
-    }
-    if ("offset-x" in confidentiality-marker) {
-      x-offset = confidentiality-marker.offset-x
-    }
-    if ("offset-y" in confidentiality-marker) {
-      y-offset = confidentiality-marker.offset-y
-    }
-    if ("size" in confidentiality-marker) {
-      size = confidentiality-marker.size
-    }
-    if ("title-spacing" in confidentiality-marker) {
-      confidentiality-marker.title-spacing
-    }
-
-    v(title-spacing)
-
-    let color = if (show-confidentiality-statement) {
-      red
-    } else {
-      green.darken(5%)
-    }
-
     place(
-      right,
-      dx: 35pt + x-offset,
-      dy: -70pt + y-offset,
-      circle(radius: size / 2, fill: color),
+      dy: 2 * page-grid,
+      bottom + center,
+      text(red, 15pt, weight: "bold", "Diese Arbeit enthält einen Sperrvermerk")
     )
   }
+
+  // if (confidentiality-marker.display) {
+  //   let size = 7em
+  //   let display = false
+  //   let title-spacing = 2em
+  //   let x-offset = 0pt
+
+  //   let y-offset = if (many-authors) {
+  //     7pt
+  //   } else {
+  //     0pt
+  //   }
+
+  //   if (type-of-thesis == none) {
+  //     title-spacing = 0em
+  //   }
+
+  //   if ("display" in confidentiality-marker) {
+  //     display = confidentiality-marker.display
+  //   }
+  //   if ("offset-x" in confidentiality-marker) {
+  //     x-offset = confidentiality-marker.offset-x
+  //   }
+  //   if ("offset-y" in confidentiality-marker) {
+  //     y-offset = confidentiality-marker.offset-y
+  //   }
+  //   if ("size" in confidentiality-marker) {
+  //     size = confidentiality-marker.size
+  //   }
+  //   if ("title-spacing" in confidentiality-marker) {
+  //     confidentiality-marker.title-spacing
+  //   }
+
+  //   v(title-spacing)
+
+  //   let color = if (show-confidentiality-statement) {
+  //     red
+  //   } else {
+  //     green.darken(5%)
+  //   }
+
+  //   place(
+  //     right,
+  //     dx: 35pt + x-offset,
+  //     dy: -70pt + y-offset,
+  //     circle(radius: size / 2, fill: color),
+  //   )
+  // }
 
   // ---------- Sub-Title-Infos ---------------------------------------
   // 
@@ -122,7 +130,6 @@
 
   // university
   text(university + [ ] + university-location)
-
 
   // ---------- Author(s) ---------------------------------------
 


### PR DESCRIPTION
The graphical confidentiality marker (colored dot) has been replaced with a clear textual notice displayed at the bottom of the page.

This change improves the visibility and recognizability of the confidentiality statement, as a text-based warning is easier to notice and understand than a purely visual marker.
<img width="466" height="667" alt="example-confidential-marker" src="https://github.com/user-attachments/assets/710183b8-f11c-4f54-9efa-ed1b4263edff" />

