### PR TITLE
Proposal: Add optional ai usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ CAVEAT: The template hasn't been adapted nor tested for more than two authors.
 
 `confidentiality-statement-content (content)`: Provide a custom confidentiality statement
 
+`ai-usage-section-content (content)`: Provide custom content for the AI usage section (e.g. a table of used tools)
+
 `date (datetime* | array*)`: Provide a datetime object to display one date (e.g. submission date) or a array containing two datetime objects to display a date range (e.g. start and end date of the project), default is `datetime.today()`
 
 `date-format (str)`: Format of the displayed dates, default is `"[day].[month].[year]"` (for more information on possible formats check the [Typst documentation](https://typst.app/docs/reference/foundations/datetime/#format))
@@ -123,6 +125,8 @@ CAVEAT: The template hasn't been adapted nor tested for more than two authors.
 `show-confidentiality-statement (bool)`: Whether the confidentiality statement should be shown, default is `true`
 
 `show-declaration-of-authorship (bool)`: Whether the declaration of authorship should be shown, default is `true`
+
+`show-ai-usage-section (bool)`: Whether the AI usage section should be shown (placed after glossary and before user-defined appendix), default is `false`
 
 `show-table-of-contents (bool)`: Whether the table of contents should be shown, default is `true`
 

--- a/ai-usage-section.typ
+++ b/ai-usage-section.typ
@@ -1,0 +1,13 @@
+#import "locale.typ": *
+
+#let ai-usage-section(
+  ai-usage-section-content,
+  language,
+) = {
+  heading(level: 1, AI_USAGE_SECTION_TITLE.at(language))
+  v(1em)
+
+  if (ai-usage-section-content != none) {
+    ai-usage-section-content
+  }
+}

--- a/check-attributes.typ
+++ b/check-attributes.typ
@@ -7,6 +7,7 @@
   type-of-thesis,
   show-confidentiality-statement,
   show-declaration-of-authorship,
+  show-ai-usage-section,
   show-table-of-contents,
   show-abstract,
   abstract,
@@ -41,6 +42,7 @@
     show-confidentiality-statement: show-confidentiality-statement,
     show-table-of-contents: show-table-of-contents,
     show-declaration-of-authorship: show-declaration-of-authorship,
+    show-ai-usage-section: show-ai-usage-section,
     show-abstract: show-abstract,
   )
 

--- a/docs/design-explained.md
+++ b/docs/design-explained.md
@@ -23,6 +23,7 @@ The document defined by the template consists of the following **parts**:
 	- References
 	- Acronyms (*optional*)
 	- Glossary (*optional*)
+	- AI Usage Section (*optional*)
 	- User-defined appendix (*optional*)
 - Legal backmatter
 	- Confidentiality Statement (*optional*)

--- a/docs/design-explained.md
+++ b/docs/design-explained.md
@@ -23,10 +23,10 @@ The document defined by the template consists of the following **parts**:
 	- References
 	- Acronyms (*optional*)
 	- Glossary (*optional*)
-	- AI Usage Section (*optional*)
 	- User-defined appendix (*optional*)
 - Legal backmatter
 	- Confidentiality Statement (*optional*)
+	- AI Usage Section (*optional*)
 	- Declaration of Authorship 
 
 I've added the "*optional*" markers from a content viewpoint to the elements in the list above. I.e. I consider them optional in a thesis or a similar document. On a technical level all components can be switched off, if desired.

--- a/lib.typ
+++ b/lib.typ
@@ -5,6 +5,7 @@
 #import "titlepage.typ": *
 #import "confidentiality-statement.typ": *
 #import "declaration-of-authorship.typ": *
+#import "ai-usage-section.typ": *
 #import "check-attributes.typ": *
 
 // Workaround for the lack of an `std` scope.
@@ -19,12 +20,14 @@
   type-of-thesis: none,
   show-confidentiality-statement: true,
   show-declaration-of-authorship: true,
+  show-ai-usage-section: false,
   show-table-of-contents: true,
   show-abstract: true,
   abstract: none,
   appendix: none,
   confidentiality-statement-content: none,
   declaration-of-authorship-content: none,
+  ai-usage-section-content: none,
   titlepage-content: none,
   university: none,
   university-location: none,
@@ -52,6 +55,7 @@
     type-of-thesis,
     show-confidentiality-statement,
     show-declaration-of-authorship,
+    show-ai-usage-section,
     show-table-of-contents,
     show-abstract,
     abstract,
@@ -309,6 +313,15 @@
   if (glossary != none) {
     heading(level: 1, GLOSSARY.at(language))
     print-glossary(glossary)
+  }
+
+  // ---------- AI Usage Section ---------------------------------------
+
+  if (show-ai-usage-section) {
+    ai-usage-section(
+      ai-usage-section-content,
+      language,
+    )
   }
 
   // ---------- Appendix (other contents) ---------------------------------------

--- a/lib.typ
+++ b/lib.typ
@@ -315,15 +315,6 @@
     print-glossary(glossary)
   }
 
-  // ---------- AI Usage Section ---------------------------------------
-
-  if (show-ai-usage-section) {
-    ai-usage-section(
-      ai-usage-section-content,
-      language,
-    )
-  }
-
   // ---------- Appendix (other contents) ---------------------------------------
 
   if (appendix != none) {       // the user has to provide heading(s)
@@ -347,6 +338,15 @@
       language,
       many-authors,
       date-format,
+    )
+  }
+
+  // ---------- AI Usage Section ---------------------------------------
+
+  if (show-ai-usage-section) {
+    ai-usage-section(
+      ai-usage-section-content,
+      language,
     )
   }
 

--- a/locale.typ
+++ b/locale.typ
@@ -41,6 +41,11 @@
 
 #let DECLARATION_OF_AUTHORSHIP_SECTION_B_PLURAL = "selbstständig verfasst und keine anderen als die angegebenen Quellen und Hilfsmittel benutzt haben. Wir versichern zudem, dass alle eingereichten Fassungen übereinstimmen."
 
+#let AI_USAGE_SECTION_TITLE = (
+  "de": "Verwendung von KI",
+  "en": "Usage of AI",
+)
+
 #let CONFIDENTIALITY_STATEMENT_TITLE = (
   "de": "Sperrvermerk",
   "en": "Confidentiality Statement",


### PR DESCRIPTION
The same as #19 (had to open a new pull request to change the branch)

## What this does

This adds an optional section between the glossary and appendix that allows for specifiying how ai tools have been used in the thesis.

## Why this is helpful

- The recently updated (november 2025) [official DHBW guidelines](https://www.mosbach.dhbw.de/fileadmin/user_upload/dhbw/studiengaenge/et/191212_Leitlinien_Praxismodule_Studien_Bachelorarbeiten.pdf) recommend adding a section like this.
- As far as I'm aware, adding it to the template is easier than inserting it from outside.